### PR TITLE
Added install instructions and blank.pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Pronounced `mɪtrə`.
 
 [What's new](NEWS.md).
 
+## Install
+
+Install MuPDF (you need mutool on the command line to create normalized PDFs)
+
+
 ## How to use
 
 `mitra.py file1.png file2.dcm` gives you a working PNG/DICOM polyglot.

--- a/blank.pdf
+++ b/blank.pdf
@@ -1,0 +1,32 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Kids[3 0 R]/Type/Pages>>
+endobj
+
+3 0 obj
+<</Type/Page/Contents 4 0 R>>
+endobj
+
+4 0 obj
+<<>>
+endobj
+
+xref
+0 5
+0000000000 65536 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000106 00000 n 
+0000000152 00000 n 
+
+trailer
+<</Size 5/Root 1 0 R>>
+startxref
+173
+%%EOF


### PR DESCRIPTION
The tool crashed for me. It had two reasons: First of all I had to do `sudo port install mupdf` on MacOS to install the dependencies. I've changed the README to include that dependency. Then it crashed with:

```
$ python3.8 mitra.py plain.pdf burp_extensions.zip
plain.pdf
File 1: Portable Document Format
burp_extensions.zip
File 2: Zip

Stack: concatenation of File1 (type PDF) and File2 (type Zip)
Parasite: hosting of File2 (type Zip) in File1 (type PDF)
error: cannot open blank.pdf: No such file or directory
error: aborting process from uncaught error!
Traceback (most recent call last):
  File "mitra.py", line 376, in <module>
    main()
  File "mitra.py", line 369, in main
    DoAll(ftype1, ftype2, fn1, fn2)
  File "mitra.py", line 317, in DoAll
    Parasite(ftype1, ftype2, fn1, fn2)
  File "mitra.py", line 242, in Parasite
    parasitized, swaps = ftype1.parasitize(ftype2)
  File "/opt/mitra/parsers/__init__.py", line 165, in parasitize
    self.normalize()
  File "/opt/mitra/parsers/pdf.py", line 123, in normalize
    with open("merged.pdf", "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'merged.pdf'
```

I saw that the code is using blank.pdf, but that was not in the repository. I've tried to use my own, but that didn't have the correct structure. So I searched and found the PDF trick code here https://github.com/corkami/collisions/tree/master/scripts which made me believe that dummy.pdf from there was the blank.pdf we need here. So I've included that dummy.pdf as blank.pdf here.

Now it works perfectly for me:

```
$ python3.8 mitra.py plain.pdf burp_extensions.zip
plain.pdf
File 1: Portable Document Format
burp_extensions.zip
File 2: Zip

Stack: concatenation of File1 (type PDF) and File2 (type Zip)
Parasite: hosting of File2 (type Zip) in File1 (type PDF)
```